### PR TITLE
format() don't take a tuple as argument

### DIFF
--- a/activemq_info.py
+++ b/activemq_info.py
@@ -104,7 +104,7 @@ else:
                 log.warning('activemq_info plugin: Unknown config key: %s.'
                             % node.key)
         amq.log_verbose('Configured with host={0}, port={1}'.format(
-            (amq.host, amq.port)))
+            amq.host, amq.port))
         collectd.register_read(amq.read_callback)
 
     def read_callback(self):


### PR DESCRIPTION
Execution of your plugin on collectd 4.10 produce the following traceback :

```
IndexError: tuple index out of range
```
