### PR TITLE
Allow collectd module to work with python2.6.

### DIFF
--- a/activemq_info.py
+++ b/activemq_info.py
@@ -7,7 +7,6 @@
 # https://github.com/powdahound/redis-collectd-plugin - was used as template
 # https://github.com/kipsnak/munin-activemq-plugin - was used as inspiration
 
-import argparse
 import pprint
 from xml.dom import minidom
 import urllib
@@ -80,6 +79,7 @@ class AMQMonitor(object):
         return metrics
 
 if __name__ == '__main__':
+    import argparse
     import logging
 
     logging.basicConfig(level=logging.DEBUG)


### PR DESCRIPTION
The argparse module was introduced in python2.7. This change should
allow the collectd module to load and run in python2.6 while allowing
the script to be used as a script in python2.7.
