### PR TITLE
Fix a typo.

### DIFF
--- a/activemq_info.py
+++ b/activemq_info.py
@@ -105,7 +105,7 @@ else:
                             % node.key)
         amq.log_verbose('Configured with host={0}, port={1}'.format(
             amq.host, amq.port))
-        collectd.register_read(amq.read_callback)
+        collectd.register_read(read_callback)
 
     def read_callback(self):
         """Collectd read callback"""


### PR DESCRIPTION
I accidentally didn't push a part of the commit when adding the support
to run as a script. I moved the read_callback to a function from a
method in the AMQMonitor object. I accidentally left the object as part
of the call to the read_callback.

Signed-off-by: Warren Turkal wt@signalfx.com
