### PR TITLE
Update activemq_info.py

### DIFF
--- a/activemq_info.py
+++ b/activemq_info.py
@@ -69,8 +69,8 @@ class AMQMonitor(object):
 
             gauges.append((queue, 'size', size))
             gauges.append((queue, 'consumerCount', consumerCount))
-            counters.append(queue, 'enqueueCount',  enqueueCount)
-            counters.append(queue, 'dequeueCount',  dequeueCount)
+            counters.append((queue, 'enqueueCount',  enqueueCount))
+            counters.append((queue, 'dequeueCount',  dequeueCount))
 
         metrics = {
             'gauges': gauges,


### PR DESCRIPTION
This change fixes :

```
Traceback (most recent call last):
  File "./activemq_info.py", line 87, in <module>
    main()
  File "./activemq_info.py", line 32, in main
    pprint.pformat(amq.fetch_metrics(), indent=2)))
  File "./activemq_info.py", line 72, in fetch_metrics
    counters.append(queue, 'enqueueCount',  enqueueCount)
TypeError: append() takes exactly one argument (3 given)
```
