### PR TITLE
Web admin root path + http auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,17 @@ Add the following to your collectd config
       </Module>
     </Plugin>
 
+Optionnal attributes can be set to configure http auth or webadmin root path :
+
+      <Module activemq_info>
+        Host "localhost"
+        Port 8161
+        User jdoe
+        Pass 123qwerty
+        Webadmin amq-admin
+      </Module>
+_It will access http://localhost:8161/amq-admin/xml/queues.jsp and authenticate with jdoe/123qwerty_
+
 License
 -------
 MIT

--- a/activemq_info.py
+++ b/activemq_info.py
@@ -111,13 +111,19 @@ else:
                 amq.host = node.values[0]
             elif node.key == 'Port':
                 amq.port = int(node.values[0])
+            elif node.key == 'User':
+                amq.login = node.values[0]
+            elif node.key == 'Pass':
+                amq.passw = node.values[0]
+            elif node.key == 'Webadmin':
+                amq.webadmin = node.values[0]
             elif node.key == 'Verbose':
                 amq.verbose_logging = bool(node.values[0])
             else:
                 log.warning('activemq_info plugin: Unknown config key: %s.'
                             % node.key)
-        amq.log_verbose('Configured with host={0}, port={1}'.format(
-            amq.host, amq.port))
+        amq.log_verbose('Configured with host={0}, port={1}, webadmin={2}, login={3}'.format(
+            amq.host, amq.port, amq.webadmin, amq.login))
         collectd.register_read(read_callback)
 
     def read_callback(self):

--- a/activemq_info.py
+++ b/activemq_info.py
@@ -9,7 +9,7 @@
 
 import pprint
 from xml.dom import minidom
-import urllib
+import requests
 
 PLUGIN_NAME = 'activemq_info'
 
@@ -18,6 +18,9 @@ def parse_args():
     parser = argparse.ArgumentParser()
     parser.add_argument('host')
     parser.add_argument('port', type=int)
+    parser.add_argument('-w', '--webadmin', default='admin')
+    parser.add_argument('-l', '--login')
+    parser.add_argument('-p', '--password')
     return parser.parse_args()
 
 
@@ -25,17 +28,24 @@ def main():
     args = parse_args()
     host = args.host
     port = args.port
+    webadmin = args.webadmin
+    login = args.login
+    passw = args.password
     log.debug('Using host {0}'.format(host))
     log.debug('Using port {0}'.format(port))
-    amq = AMQMonitor(host=host, port=port, verbose_logging=True)
-    log.debug('Metrics to send:\n{0}'.format(
-        pprint.pformat(amq.fetch_metrics(), indent=2)))
+    if login:
+      log.debug('Authenticating with {0}'.format(login))
+    amq = AMQMonitor(host=host, port=port, webadmin=webadmin, login=login, passw=passw, verbose_logging=True)
+    log.debug('Metrics to send:\n{0}'.format(pprint.pformat(amq.fetch_metrics(), indent=2)))
 
 
 class AMQMonitor(object):
-    def __init__(self, host='localhost', port=8161, verbose_logging=False):
+    def __init__(self, host='localhost', port=8161, webadmin='admin', login='', passw='', verbose_logging=False):
         self.host = host
         self.port = port
+        self.webadmin = webadmin
+        self.login = login
+        self.passw = passw
         self.verbose_logging = verbose_logging
 
     def log_verbose(self, msg):
@@ -45,10 +55,13 @@ class AMQMonitor(object):
 
     def fetch_metrics(self):
         """Connect to ActiveMQ admin webpage and return DOM object"""
-        url = 'http://%s:%s/admin/xml/queues.jsp' % (self.host, self.port)
+        url = 'http://%s:%s/%s/xml/queues.jsp' % (self.host, self.port, self.webadmin)
         dom = None
         try:
-            dom = minidom.parse(urllib.urlopen(url))
+            if self.login:
+                dom = minidom.parseString(requests.get(url, auth=(self.login, self.passw)).text)
+            else:
+                dom = minidom.parseString(requests.get(url).text)
         except Exception:
             self.log_verbose('activemq_info plugin: No info received, '
                              'offline node or turned off ActiveMQ')


### PR DESCRIPTION
Hi !
I'm using a broker with a modified webadmin path + a protected http access : 
- URL `http://my-broker.local:8161/activemq-console/xml/queues.jsp` is working after a http auth step.

But this collectd module can't handle auth nor webadmin path changes : 

```
> ./activemq_info.py my-broker.local 8161
DEBUG:__main__:Using host my-broker.local
DEBUG:__main__:Using port 8161
Enter username for ActiveMQRealm at my-broker.local:8161: <handtyped_user>
Enter password for iprint in ActiveMQRealm at my-broker.local:8161: <handtyped_password>
INFO:__main__:activemq_info plugin [verbose]: activemq_info plugin: No info received, offline node or turned off ActiveMQ
DEBUG:__main__:Metrics to send:
None
```

_urllib seems waiting user console input for credentials, which is not really great for an automated process_

To make it work in any situation, I've made multiple changes here : 
- switching from `urllib` to `requests` : requests handles http auth way easier.
- adding `-w / --webadmin` option that allow to change default webadmin root path 
  - default is still `.../admin/...`
- adding `-l / --login` and `-p / --password` to handle http auth.
  - authentication is tried only if login option is specified.

**Result :** 

```
> ./activemq_info.py my-broker.local 8161 -w activemq-console -l my_user -p my_pass
DEBUG:__main__:Using host my-broker.local
DEBUG:__main__:Using port 8161
DEBUG:__main__:Authenticating with my_user
INFO:urllib3.connectionpool:Starting new HTTP connection (1): my-broker.local
DEBUG:urllib3.connectionpool:"GET /activemq-console/xml/queues.jsp HTTP/1.1" 200 3250
DEBUG:__main__:Metrics to send:
{ 'counters': [ (u'ORDER_IN', 'enqueueCount', u'1'),
                (u'ORDER_IN', 'dequeueCount', u'0'),
              [...]
              ],
  'gauges': [ (u'ORDER_IN', 'size', u'1'),
              (u'ORDER_IN', 'consumerCount', u'0'),
              [...]
              ]}
```
